### PR TITLE
Update the conda build in CI

### DIFF
--- a/.github/workflows/dev_tests.yml
+++ b/.github/workflows/dev_tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - python-dev
+      - conda-build-ci
   pull_request:
     branches:
       - python-dev
@@ -39,24 +40,30 @@ jobs:
         python-version: ["3.11"]
     name: test with python ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -l {0}
     steps:
       - uses: actions/checkout@v3
-      - uses: mamba-org/setup-micromamba@v1
+      - name: Setup miniconda
+        uses: conda-incubator/setup-miniconda@v2
         with:
+          auto-update-conda: true
+          miniforge-variant: Mambaforge
+          channels: conda-forge
+          python-version: 3.11
+          activate-environment: soprano-dev
           environment-file: src/SOPRANO/local.yml
-          init-shell: bash
+          use-mamba: true
       - name: Install SOPRANO
-        shell: bash -l {0}
         run: |
-          micromamba activate soprano-dev
+          conda activate soprano-dev
           pip install -e .[ci]
       - name: Test conda environment
-        shell: bash -l {0}
         run: |
-          micromamba activate soprano-dev
+          conda activate soprano-dev
           pytest tests/test_configuration
       - name: Test units
-        shell: bash -l {0}
         run: |
-          micromamba activate soprano-dev
+          conda activate soprano-dev
           pytest tests/test_units

--- a/.github/workflows/dev_tests.yml
+++ b/.github/workflows/dev_tests.yml
@@ -53,7 +53,7 @@ jobs:
           channels: conda-forge
           python-version: 3.11
           activate-environment: soprano-dev
-          environment-file: src/SOPRANO/local.yml
+          environment-file: src/SOPRANO/ci_linux.yml
           use-mamba: true
       - name: Install SOPRANO
         run: |

--- a/.github/workflows/dev_tests.yml
+++ b/.github/workflows/dev_tests.yml
@@ -1,45 +1,14 @@
 name: SOPRANO (Dev) Tests
 
 on:
-  push:
-    branches:
-      - python-dev
-      - conda-build-ci
   pull_request:
     branches:
       - python-dev
 
 jobs:
-  lint:
-    strategy:
-      matrix:
-        os: ["ubuntu-latest"]
-        python-version: ["3.11"]
-    name: lint with python ${{ matrix.python-version }} on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install ruff and black
-        run: |
-          python -m pip install --upgrade pip
-          pip install ruff black
-      - name: Lint check with ruff
-        run: |
-          ruff --target-version=py311 --line-length 79 .
-      - name: Style check with black
-        run: |
-          black ./ --check --line-length 79
   test:
-    strategy:
-      matrix:
-        os: ["ubuntu-latest"]
-        python-version: ["3.11"]
-    name: test with python ${{ matrix.python-version }} on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: Development tests
+    runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash -l {0}
@@ -62,8 +31,8 @@ jobs:
       - name: Test conda environment
         run: |
           conda activate soprano-dev
-          pytest tests/test_configuration
+          pytest -s tests/test_configuration
       - name: Test units
         run: |
           conda activate soprano-dev
-          pytest tests/test_units
+          pytest -s tests/test_units

--- a/.github/workflows/lint_and_style.yml
+++ b/.github/workflows/lint_and_style.yml
@@ -1,0 +1,23 @@
+name: Lint and style check
+
+on: [ push ]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+      - name: Install ruff and black
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff black
+      - name: Lint check with ruff
+        run: |
+          ruff --target-version=py311 --line-length 79 .
+      - name: Style check with black
+        run: |
+          black ./ --check --line-length 79

--- a/.github/workflows/main_tests.yml
+++ b/.github/workflows/main_tests.yml
@@ -1,69 +1,42 @@
-name: SOPRANO (Main) Tests
+name: SOPRANO Tests
 
 on:
-  push:
-    branches:
-      - python
-      - master
   pull_request:
     branches:
       - python
-      - master
+      - main
 
 jobs:
-  lint:
-    strategy:
-      matrix:
-        os: ["ubuntu-latest"]
-        python-version: ["3.11"]
-    name: lint with python ${{ matrix.python-version }} on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install ruff and black
-        run: |
-          python -m pip install --upgrade pip
-          pip install ruff black
-      - name: Lint check with ruff
-        run: |
-          ruff --format=github --target-version=py311 --line-length 79 .
-      - name: Style check with black
-        run: |
-          black ./ --check --line-length 79
   test:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
-        python-version: ["3.11"]
-    name: test with python ${{ matrix.python-version }} on ${{ matrix.os }}
+        os: [ "ubuntu-latest", "macos-latest" ]
+    name: Development tests on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -l {0}
     steps:
       - uses: actions/checkout@v3
-      - uses: mamba-org/setup-micromamba@v1
+      - name: Setup miniconda
+        uses: conda-incubator/setup-miniconda@v2
         with:
-          environment-file: src/SOPRANO/local.yml
-          init-shell: bash
+          auto-update-conda: true
+          miniforge-variant: Mambaforge
+          channels: conda-forge
+          python-version: 3.11
+          activate-environment: soprano-dev
+          environment-file: src/SOPRANO/ci_osx.yml  # additional coreutils
+          use-mamba: true
       - name: Install SOPRANO
-        shell: bash -l {0}
         run: |
-          micromamba activate soprano-dev
+          conda activate soprano-dev
           pip install -e .[ci]
       - name: Test conda environment
-        shell: bash -l {0}
         run: |
-          micromamba activate soprano-dev
-          pytest tests/test_configuration
+          conda activate soprano-dev
+          pytest -s tests/test_configuration
       - name: Test units
-        shell: bash -l {0}
         run: |
-          micromamba activate soprano-dev
-          pytest tests/test_units
-#      - name: Test integration # TODO: Need to think about this
-#        shell: bash -l {0}
-#        run: |
-#          micromamba activate soprano-dev
-#          pytest tests/test_integrations
+          conda activate soprano-dev
+          pytest -s tests/test_units

--- a/src/SOPRANO/ci_linux.yml
+++ b/src/SOPRANO/ci_linux.yml
@@ -1,0 +1,19 @@
+channels:
+  - conda-forge
+  - bioconda
+  - anaconda
+dependencies:
+  - perl
+  - bedtools=2.31.0
+  - python>=3.10,<3.12
+  - pip
+  - pandas
+  - numpy
+  - streamlit==1.27.0
+  - requests
+  - types-requests
+  - clint
+  - black
+  - pytest
+  - pytest-dependency
+  - ruff

--- a/src/SOPRANO/ci_osx.yml
+++ b/src/SOPRANO/ci_osx.yml
@@ -1,0 +1,20 @@
+channels:
+  - conda-forge
+  - bioconda
+  - anaconda
+dependencies:
+  - perl
+  - bedtools=2.31.0
+  - python>=3.10,<3.12
+  - coreutils
+  - pip
+  - pandas
+  - numpy
+  - streamlit==1.27.0
+  - requests
+  - types-requests
+  - clint
+  - black
+  - pytest
+  - pytest-dependency
+  - ruff

--- a/tests/test_configuration/test_setup_conda.py
+++ b/tests/test_configuration/test_setup_conda.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from SOPRANO.utils.env_utils import (
@@ -7,6 +9,8 @@ from SOPRANO.utils.env_utils import (
     running_soprano_env,
     vep_installed,
 )
+
+IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
 
 
 @pytest.mark.dependency(name="has_conda")
@@ -19,6 +23,7 @@ def test_running_soprano_env():
     assert running_soprano_env()
 
 
+@pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Not built in CI (for now)")
 @pytest.mark.dependency(depends=["has_conda"])
 def test_vep_installed():
     assert vep_installed()

--- a/tests/test_units/test_url_utils.py
+++ b/tests/test_units/test_url_utils.py
@@ -1,9 +1,12 @@
+import os
 import pickle as pk
 
 import pytest
 
 import SOPRANO.core.objects
 from SOPRANO.utils import url_utils
+
+IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
 
 
 def test_filename_from_url():
@@ -15,6 +18,7 @@ def test_filename_from_url():
     assert url_utils.filename_from_url(joined) == file_name
 
 
+@pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Too slow...")
 def test_download_from_url(tmp_path):
     test_url = "https://www.icr.ac.uk/assets/img/logo_share.jpg"
     test_target_path = tmp_path.joinpath("icr_logo.jpg")
@@ -81,6 +85,7 @@ def test_get_cached_release_value(backup_releases_cache):
     backup_releases_path.rename(url_utils._SOPRANO_ENSEMBL_RELEASES)
 
 
+@pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Too slow...")
 def test_find_earliest_release(backup_releases_cache):
     toplevel_url = (
         "https://ftp.ensembl.org/pub/release-{RELEASE}/fasta/"


### PR DESCRIPTION
- Previously using micromamba action but this appears to have broken. Updated to use miniconda action with mamba variants applied.
- Run lint and style checks on all pushs
- Updates to dev and main test worklows to minimize installations
- Pytest skips some tests (requests and ensembl checks) since these are quite slow 