### PR TITLE
Hotfix vep link

### DIFF
--- a/src/SOPRANO/utils/url_utils.py
+++ b/src/SOPRANO/utils/url_utils.py
@@ -76,10 +76,14 @@ def compute_fasta_index(fa_path: pathlib.Path):
 
     index_path = fa_path.with_suffix(".fa.fai")
 
-    task_output(f"Computing fasta index file from {fa_path}")
-    pipe(
-        ["samtools", "faidx", fa_path.as_posix(), "-o", index_path.as_posix()]
-    )
+    if not index_path.exists():
+        task_output(f"Computing fasta index file from {fa_path}")
+        pipe(
+            ["samtools", "faidx", fa_path.as_posix(), "-o", index_path.as_posix()]
+        )
+    else:
+        task_output(f"Fasta index file already exists {fa_path}")
+    return index_path
 
 
 def compute_chrom_sizes(fai_path: pathlib.Path):
@@ -91,9 +95,12 @@ def compute_chrom_sizes(fai_path: pathlib.Path):
 
     chrom_path = fai_path.with_suffix("").with_suffix(".chrom")
 
-    task_output(f"Computing chromosome sizes from {fai_path}")
-    pipe(["cut", "-f1,2", fai_path.as_posix()], output_path=chrom_path)
-
+    if not chrom_path.exists():
+        task_output(f"Computing chromosome sizes from {fai_path}")
+        pipe(["cut", "-f1,2", fai_path.as_posix()], output_path=chrom_path)
+    else:
+        task_output(f"Chromosome sizes file already exists {chrom_path}")
+    return chrom_path
 
 def get_dna_url(species: str):
     return (

--- a/src/SOPRANO/utils/url_utils.py
+++ b/src/SOPRANO/utils/url_utils.py
@@ -79,7 +79,13 @@ def compute_fasta_index(fa_path: pathlib.Path):
     if not index_path.exists():
         task_output(f"Computing fasta index file from {fa_path}")
         pipe(
-            ["samtools", "faidx", fa_path.as_posix(), "-o", index_path.as_posix()]
+            [
+                "samtools",
+                "faidx",
+                fa_path.as_posix(),
+                "-o",
+                index_path.as_posix(),
+            ]
         )
     else:
         task_output(f"Fasta index file already exists {fa_path}")
@@ -101,6 +107,7 @@ def compute_chrom_sizes(fai_path: pathlib.Path):
     else:
         task_output(f"Chromosome sizes file already exists {chrom_path}")
     return chrom_path
+
 
 def get_dna_url(species: str):
     return (

--- a/src/SOPRANO/utils/vep_utils.py
+++ b/src/SOPRANO/utils/vep_utils.py
@@ -3,7 +3,7 @@ import pathlib
 from typing import List, Tuple
 
 from SOPRANO.utils.path_utils import Directories
-from SOPRANO.utils.sh_utils import pipe
+from SOPRANO.utils.url_utils import compute_fasta_index, compute_chrom_sizes
 
 
 def _get_src_dst_link_pairs(vep_cache: pathlib.Path):
@@ -50,39 +50,27 @@ def _process(
     compute_chroms: bool,
 ):
     fa_glob = list(src_dir.glob(f"*dna.{pattern}*.fa"))
-    fai_glob = list(src_dir.glob(f"*dna.{pattern}*.fai"))
 
     src_fa_found = len(fa_glob) == 1
-    src_fai_found = len(fai_glob) == 1
 
-    if src_fa_found or src_fai_found:
+    if src_fa_found:
         if not dst_dir.exists():
             print(f"Building directory: {dst_dir}")
             dst_dir.mkdir(parents=True)
     else:
-        print(
-            f"No appropriate fasta or fasta index files detected in {src_dir} "
-            f"for {pattern}"
-        )
+        print(f"No fasta files detected in {src_dir}")
 
     if src_fa_found:
         src_fa = fa_glob[0]
         dst_fa = dst_dir.joinpath(src_fa.name)
-
         if not dst_fa.exists():
-            print(f"Sym linking {src_fa} -> {dst_fa}")
-            dst_fa.symlink_to(src_fa)
+            print(f"Linking {src_fa} -> {dst_fa}")
+            dst_fa.hardlink_to(src_fa)
 
-        dst_chrom = dst_fa.with_suffix(".chrom")
-        if not dst_chrom.exists() and compute_chroms:
-            print(f"Computing chrom sizes: {dst_chrom}")
-            pipe(["cut", "-f1,2", src_fa.as_posix()], output_path=dst_chrom)
+        dst_fai = compute_fasta_index(dst_fa)
 
-    if src_fai_found:
-        src_fai = fai_glob[0]
-        dst_fai = dst_dir.joinpath(src_fai.name)
-        print(f"Sym linking {src_fai} -> {dst_fai}")
-        dst_fai.symlink_to(src_fai)
+        if compute_chroms:
+            compute_chrom_sizes(dst_fai)
 
 
 def _link_src_dst_pairs(


### PR DESCRIPTION
When linking vep cache files, the subsequent computation of fai and chrom sizes was incorrect. This has now been fixed to match that of the genome downloader. Fasta index files are now not copied from the cache but computed, takes a bit of time, but ensures we are using consistent definitions for subsequent chromosome files, etc.