### PR TITLE
63 let soprano work with configuration file

### DIFF
--- a/src/SOPRANO/run.py
+++ b/src/SOPRANO/run.py
@@ -8,6 +8,7 @@ from SOPRANO.utils.parse_utils import (
     parse_args,
     parse_genome_args,
     parse_hla,
+    parse_link_vep_cache_args,
     parse_vcf_sources,
 )
 from SOPRANO.utils.path_utils import Directories
@@ -15,7 +16,6 @@ from SOPRANO.utils.print_utils import startup_output
 from SOPRANO.utils.vep_utils import (
     _get_src_dst_link_pairs,
     _link_src_dst_pairs,
-    _link_vep_cache_parser,
 )
 
 
@@ -32,7 +32,7 @@ def run_app():
 
 
 def link_vep_cache():
-    src_cache = _link_vep_cache_parser()
+    src_cache = parse_link_vep_cache_args()
     src_dst_links = _get_src_dst_link_pairs(src_cache)
     _link_src_dst_pairs(src_dst_links)
 

--- a/src/SOPRANO/utils/parse_utils.py
+++ b/src/SOPRANO/utils/parse_utils.py
@@ -63,7 +63,9 @@ def parse_genome_args(argv=None):
 
 
 def parse_args(argv=None):
-    parser = argparse.ArgumentParser(description="SOPRANO input arguments")
+    parser = argparse.ArgumentParser(
+        description="SOPRANO input arguments", fromfile_prefix_chars="@"
+    )
 
     parser.add_argument(
         "--input",

--- a/src/SOPRANO/utils/parse_utils.py
+++ b/src/SOPRANO/utils/parse_utils.py
@@ -11,7 +11,7 @@ def _add_core_genome_args(parser: argparse.ArgumentParser):
         "-s",
         dest="species",
         type=str,
-        help="Ensembl species Latin name. " "Default: homo_sapiens.",
+        help="Ensembl species Latin name.",
         default="homo_sapiens",
     )
 
@@ -20,7 +20,7 @@ def _add_core_genome_args(parser: argparse.ArgumentParser):
         "-a",
         dest="assembly",
         type=str,
-        help="Ensembl genome assembly ID. Default: GRCh38.",
+        help="Ensembl genome assembly ID.",
         default="GRCh38",
     )
 
@@ -29,7 +29,7 @@ def _add_core_genome_args(parser: argparse.ArgumentParser):
         "-r",
         dest="release",
         type=int,
-        help="Ensembl release number. Default: 110.",
+        help="Ensembl release number.",
         default=110,
     )
 
@@ -46,7 +46,10 @@ def fix_ns_species_arg(_namespace: argparse.Namespace) -> argparse.Namespace:
 
 
 def parse_genome_args(argv=None):
-    parser = argparse.ArgumentParser(description="Genome reference")
+    parser = argparse.ArgumentParser(
+        description="Genome reference",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
     parser = _add_core_genome_args(parser)
 
     parser.add_argument(
@@ -64,7 +67,9 @@ def parse_genome_args(argv=None):
 
 def parse_args(argv=None):
     parser = argparse.ArgumentParser(
-        description="SOPRANO input arguments", fromfile_prefix_chars="@"
+        description="SOPRANO input arguments",
+        fromfile_prefix_chars="@",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
 
     parser.add_argument(
@@ -125,7 +130,7 @@ def parse_args(argv=None):
         "--use_random",
         dest="use_random",
         action="store_true",
-        help="If flag is used, calculate a dNdS calue for a random region "
+        help="If flag is used, calculate a dNdS value for a random region "
         "similar to the target.",
     )
 
@@ -143,9 +148,8 @@ def parse_args(argv=None):
         dest="seed",
         default=-1,
         type=int,
-        help="Provide seed value for shuffle process in randomization. By "
-        "default, seed value is < 0, for which, no seed value will be "
-        "applied.",
+        help="Provide seed value for shuffle process in randomization. "
+        "If seed value is < 0, no seed value will be applied.",
     )
 
     transcript_args = parser.add_argument_group()
@@ -154,8 +158,7 @@ def parse_args(argv=None):
         "--transcript",
         "-t",
         dest="transcript",
-        help=f"Provide path to transcript file. Default: "
-        f"{objects.TranscriptPaths.defaults().transcript_length}",
+        help="Provide path to transcript file",
         default=objects.TranscriptPaths.defaults().transcript_length,
         type=pathlib.Path,
     )
@@ -164,8 +167,7 @@ def parse_args(argv=None):
         "--protein_transcript",
         "-p",
         dest="protein_transcript",
-        help=f"Provide path to protein transcript file. Default: "
-        f"{objects.TranscriptPaths.defaults().protein_transcript_length}",
+        help="Provide path to protein transcript file",
         default=objects.TranscriptPaths.defaults().protein_transcript_length,
         type=pathlib.Path,
     )
@@ -174,8 +176,7 @@ def parse_args(argv=None):
         "--fasta",
         "-f",
         dest="transcript_ids",
-        help=f"Provide path to the ensembl transcript IDs fasta file. "
-        f"Default: {objects.TranscriptPaths.defaults().transcript_fasta}",
+        help="Provide path to the ensembl transcript IDs fasta file.",
         default=objects.TranscriptPaths.defaults().transcript_fasta,
         type=pathlib.Path,
     )
@@ -197,7 +198,10 @@ def parse_args(argv=None):
 
 
 def parse_hla(argv=None):
-    parser = argparse.ArgumentParser("Parse HLA parameters")
+    parser = argparse.ArgumentParser(
+        "Parse HLA parameters",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
     parser.add_argument(
         "--alleles",
         "-a",
@@ -221,8 +225,7 @@ def parse_hla(argv=None):
         dest="cache_dir",
         type=pathlib.Path,
         default=Directories.app_immunopeptidomes(),
-        help=f"Cache location for immunopeptidome file. "
-        f"Default: {Directories.app_immunopeptidomes()}",
+        help="Cache location for immunopeptidome file.",
     )
     parser.add_argument(
         "--restrict",
@@ -231,7 +234,7 @@ def parse_hla(argv=None):
         nargs="*",
         type=str,
         required=False,
-        help="Space seperated Ensembl transcript IDs. Default: []",
+        help="Space seperated Ensembl transcript IDs.",
         default=[],
     )
     parser.add_argument(
@@ -241,7 +244,7 @@ def parse_hla(argv=None):
         nargs="*",
         type=str,
         required=False,
-        help="Space seperated Ensembl transcript IDs. Default: []",
+        help="Space seperated Ensembl transcript IDs.",
         default=[],
     )
 
@@ -249,7 +252,10 @@ def parse_hla(argv=None):
 
 
 def parse_vcf_sources(argv=None):
-    parser = argparse.ArgumentParser(description="VCF file annotations")
+    parser = argparse.ArgumentParser(
+        description="VCF file annotations",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
 
     parser.add_argument(
         "--source",
@@ -271,17 +277,41 @@ def parse_vcf_sources(argv=None):
         dest="cache_dir",
         type=pathlib.Path,
         default=Directories.app_annotated_inputs(),
-        help=f"Provide path to directory that will contain output. Default: "
-        f"{Directories.app_annotated_inputs()}",
+        help="Provide path to directory that will contain output.",
     )
     parser.add_argument(
         "--assembly",
         "-a",
         dest="assembly",
         type=str,
-        help="Provide the genome assembly associated with the VCF sources."
-        "Default: GRCh38.",
+        help="Provide the genome assembly associated with the VCF sources.",
         default="GRCh38",
     )
 
     return parser.parse_args(argv)
+
+
+def parse_link_vep_cache_args():
+    parser = argparse.ArgumentParser(
+        description="VEP cache parser",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    parser.add_argument(
+        "--cache",
+        "-c",
+        dest="src_cache",
+        type=pathlib.Path,
+        help="Provide the path to the ensembl vep cache.",
+        default=Directories.std_sys_vep(),
+    )
+
+    src_cache: pathlib.Path = parser.parse_args().src_cache
+
+    if not src_cache.exists():
+        raise FileNotFoundError(src_cache)
+
+    if not src_cache.is_dir():
+        raise NotADirectoryError(src_cache)
+
+    return src_cache

--- a/src/SOPRANO/utils/vep_utils.py
+++ b/src/SOPRANO/utils/vep_utils.py
@@ -1,4 +1,3 @@
-import argparse
 import pathlib
 from typing import List, Tuple
 
@@ -102,27 +101,3 @@ def _link_vep_cache(vep_cache: pathlib.Path):
     else:
         src_dst = _get_src_dst_link_pairs(vep_cache)
         _link_src_dst_pairs(src_dst)
-
-
-def _link_vep_cache_parser():
-    parser = argparse.ArgumentParser(description="VEP cache parser")
-
-    parser.add_argument(
-        "--cache",
-        "-c",
-        dest="src_cache",
-        type=pathlib.Path,
-        help="Provide the path to the ensembl vep cache. By default, will "
-        "attempt to link sources from $HOME/.vep",
-        default=Directories.std_sys_vep(),
-    )
-
-    src_cache: pathlib.Path = parser.parse_args().src_cache
-
-    if not src_cache.exists():
-        raise FileNotFoundError(src_cache)
-
-    if not src_cache.is_dir():
-        raise NotADirectoryError(src_cache)
-
-    return src_cache


### PR DESCRIPTION
Instead of having to pass all args `soprano-run -i foo -b bar ` we can now use `soprano-run @path/to/params`, where `params` contains the defintions

```
-i=foo
-b=bar
```

Note that short or long flags can be used, and defs over seperate lines. Instead of spaces, arg defs should use `=`, which is an important distinction from the CLI convention.

Additionally, there is some minor refactoring to the default view on `--help` calls.