### PR TITLE
66 generalize runtime to use samples

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,11 @@ dev = [
     "pytest-dependency",
     "isort",
     "pre-commit",
-    "mypy"
+    "mypy",
+    "mpi4py"
+]
+mpi = [
+    "mpi4py"
 ]
 ci = [
     "black",

--- a/src/SOPRANO/core/objects.py
+++ b/src/SOPRANO/core/objects.py
@@ -203,6 +203,7 @@ _NAMESPACE_KEYS = (
     "species",
     "assembly",
     "release",
+    "n_samples",
 )
 
 
@@ -220,6 +221,7 @@ class Parameters(AnalysisPaths):
         seed: int,
         transcripts: TranscriptPaths,
         genomes: GenomePaths,
+        n_samples: int,
     ):
         super().__init__(
             analysis_name, input_path, bed_path, cache_dir, random_regions
@@ -232,6 +234,7 @@ class Parameters(AnalysisPaths):
         self.use_random = use_random
         self.exclude_drivers = exclude_drivers
         self.seed = None if seed < 0 else seed
+        self.n_samples = n_samples
 
     @classmethod
     def from_namespace(cls, namespace: Namespace):
@@ -263,6 +266,8 @@ class Parameters(AnalysisPaths):
                 species=species, assembly=assembly
             ).get_genome_reference_paths(release)
 
+        n_samples = namespace.n_samples
+
         return cls(
             analysis_name=namespace.analysis_name,
             input_path=namespace.input_path,
@@ -275,6 +280,7 @@ class Parameters(AnalysisPaths):
             seed=namespace.seed,
             transcripts=transcripts,
             genomes=genomes,
+            n_samples=n_samples,
         )
 
 

--- a/src/SOPRANO/run.py
+++ b/src/SOPRANO/run.py
@@ -22,8 +22,15 @@ from SOPRANO.utils.vep_utils import (
 def run_cli(_namespace=None):
     cli_args = parse_args() if _namespace is None else _namespace
     startup_output(**cli_args.__dict__)
-    params = objects.Parameters.from_namespace(cli_args)
-    run_pipeline(params)
+
+    global_parameters = objects.GlobalParameters.from_namespace(cli_args)
+
+    worker_samples_parameters = global_parameters.get_worker_samples()
+
+    for parameters in worker_samples_parameters:
+        run_pipeline(parameters)
+
+    global_parameters.gather()
 
 
 def run_app():
@@ -35,6 +42,7 @@ def link_vep_cache():
     src_cache = parse_link_vep_cache_args()
     src_dst_links = _get_src_dst_link_pairs(src_cache)
     _link_src_dst_pairs(src_dst_links)
+    # TODO: Just use _link_vep_cache !
 
 
 def download_genome():

--- a/src/SOPRANO/run.py
+++ b/src/SOPRANO/run.py
@@ -4,6 +4,7 @@ from SOPRANO import hla2ip
 from SOPRANO.core import objects
 from SOPRANO.pipeline import run_pipeline
 from SOPRANO.utils.anno_utils import annotate_source
+from SOPRANO.utils.mpi_utils import RANK
 from SOPRANO.utils.parse_utils import (
     parse_args,
     parse_genome_args,
@@ -21,13 +22,17 @@ from SOPRANO.utils.vep_utils import (
 
 def run_cli(_namespace=None):
     cli_args = parse_args() if _namespace is None else _namespace
-    startup_output(**cli_args.__dict__)
-
     global_parameters = objects.GlobalParameters.from_namespace(cli_args)
+    startup_output(**global_parameters.__dict__)
 
     worker_samples_parameters = global_parameters.get_worker_samples()
 
     for parameters in worker_samples_parameters:
+        print(
+            f"Worker %05d running pipeline component: "
+            f"{parameters.analysis_name}" % RANK
+        )
+
         run_pipeline(parameters)
 
     global_parameters.gather()

--- a/src/SOPRANO/utils/_MPI.py
+++ b/src/SOPRANO/utils/_MPI.py
@@ -1,0 +1,24 @@
+class COMM_WORLD:
+    @staticmethod
+    def Barrier():
+        pass
+
+    @staticmethod
+    def Get_rank():
+        return 0
+
+    @staticmethod
+    def Get_size():
+        return 1
+
+    @staticmethod
+    def send(*args, **kwargs):
+        pass
+
+    @staticmethod
+    def recv(*args, **kwargs):
+        raise RuntimeError("Invalid operation for single mpi process.")
+
+
+def Finalize():
+    pass

--- a/src/SOPRANO/utils/mpi_utils.py
+++ b/src/SOPRANO/utils/mpi_utils.py
@@ -3,4 +3,49 @@ try:
 except ImportError:
     import _MPI as MPI
 
+from copy import deepcopy
+from typing import Callable
+
 print(f"-- Loaded MPI module: {MPI.__file__}")
+
+
+def item_selection(
+    items_to_distribute: list | dict, mpi_rank: int, mpi_size: int
+) -> list:
+    if isinstance(items_to_distribute, dict):
+        items_to_distribute = list(items_to_distribute.keys())
+
+    if mpi_size == 1:
+        return items_to_distribute
+
+    items_to_distribute = deepcopy(items_to_distribute)
+
+    current_idx = 0
+    output: dict[int, list] = {k: [] for k in range(mpi_size)}
+
+    while items_to_distribute:
+        if current_idx == mpi_size:
+            current_idx = 0
+
+        output[current_idx].append(items_to_distribute.pop(0))
+
+        current_idx += 1
+
+    return output[mpi_rank]
+
+
+def as_single_process(
+    current_proc: int, mpi_comm: MPI.COMM_WORLD, executing_proc: int = 0
+):
+    def decorator(function: Callable):
+        def wrapper(*args, **kwargs):
+            if current_proc == executing_proc:
+                result = function(*args, **kwargs)
+            else:
+                result = None
+            mpi_comm.Barrier()
+            return result
+
+        return wrapper
+
+    return decorator

--- a/src/SOPRANO/utils/mpi_utils.py
+++ b/src/SOPRANO/utils/mpi_utils.py
@@ -6,11 +6,15 @@ except ImportError:
 from copy import deepcopy
 from typing import Callable
 
-print(f"-- Loaded MPI module: {MPI.__file__}")
+COMM = MPI.COMM_WORLD
+RANK = COMM.Get_rank()
+SIZE = COMM.Get_size()
 
 
 def item_selection(
-    items_to_distribute: list | dict, mpi_rank: int, mpi_size: int
+    items_to_distribute: list | dict,
+    mpi_rank: int = RANK,
+    mpi_size: int = SIZE,
 ) -> list:
     if isinstance(items_to_distribute, dict):
         items_to_distribute = list(items_to_distribute.keys())
@@ -35,7 +39,9 @@ def item_selection(
 
 
 def as_single_process(
-    current_proc: int, mpi_comm: MPI.COMM_WORLD, executing_proc: int = 0
+    current_proc: int = RANK,
+    mpi_comm: MPI.COMM_WORLD = COMM,
+    executing_proc: int = 0,
 ):
     def decorator(function: Callable):
         def wrapper(*args, **kwargs):
@@ -43,6 +49,7 @@ def as_single_process(
                 result = function(*args, **kwargs)
             else:
                 result = None
+
             mpi_comm.Barrier()
             return result
 

--- a/src/SOPRANO/utils/mpi_utils.py
+++ b/src/SOPRANO/utils/mpi_utils.py
@@ -1,7 +1,7 @@
 try:
     from mpi4py import MPI
 except ImportError:
-    import _MPI as MPI
+    import SOPRANO.utils._MPI as MPI
 
 from copy import deepcopy
 from typing import Callable

--- a/src/SOPRANO/utils/mpi_utils.py
+++ b/src/SOPRANO/utils/mpi_utils.py
@@ -1,0 +1,6 @@
+try:
+    from mpi4py import MPI
+except ImportError:
+    import _MPI as MPI
+
+print(f"-- Loaded MPI module: {MPI.__file__}")

--- a/src/SOPRANO/utils/parse_utils.py
+++ b/src/SOPRANO/utils/parse_utils.py
@@ -152,6 +152,15 @@ def parse_args(argv=None):
         "If seed value is < 0, no seed value will be applied.",
     )
 
+    analysis_params_group.add_argument(
+        "--n_samples",
+        "-z",
+        dest="n_samples",
+        default=0,
+        type=int,
+        help="Provide number of samples to use in dNdS error estimates.",
+    )
+
     transcript_args = parser.add_argument_group()
 
     transcript_args.add_argument(

--- a/src/SOPRANO/utils/parse_utils.py
+++ b/src/SOPRANO/utils/parse_utils.py
@@ -126,13 +126,13 @@ def parse_args(argv=None):
         help="If flag is used ssb192 will be used, otherwise ssb7.",
     )
 
-    analysis_params_group.add_argument(
-        "--use_random",
-        dest="use_random",
-        action="store_true",
-        help="If flag is used, calculate a dNdS value for a random region "
-        "similar to the target.",
-    )
+    # analysis_params_group.add_argument(
+    #     "--use_random",
+    #     dest="use_random",
+    #     action="store_true",
+    #     help="If flag is used, calculate a dNdS value for a random region "
+    #     "similar to the target.",
+    # )
 
     analysis_params_group.add_argument(
         "--keep_drivers",

--- a/src/SOPRANO/utils/print_utils.py
+++ b/src/SOPRANO/utils/print_utils.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 
+from SOPRANO.utils.mpi_utils import as_single_process
+
 
 def time_output():
     now = datetime.now()
@@ -7,7 +9,11 @@ def time_output():
 
 
 def task_output(msg):
-    print(f"[{time_output()}] {msg}")
+    print(f"[{time_output()}] {msg}", flush=True)
+
+
+def line_output(n=60):
+    print("-" * n, flush=True)
 
 
 def title_output():
@@ -18,23 +24,21 @@ def title_output():
 ███████ ██    ██ ██████  ██████  ███████ ██ ██  ██ ██    ██ 
      ██ ██    ██ ██      ██   ██ ██   ██ ██  ██ ██ ██    ██ 
 ███████  ██████  ██      ██   ██ ██   ██ ██   ████  ██████  
-"""
+""",
+        flush=True,
     )
+    line_output()
+    print("Selection On PRotein ANnotated regiOns", flush=True)
+    line_output()
 
 
-def line_output(n=60):
-    print("-" * n)
-
-
+@as_single_process()
 def startup_output(**kwargs):
     title_output()
-    line_output()
-    print("Selection On PRotein ANnotated regiOns")
-    line_output()
 
     if kwargs:
-        # Parameters used in pipeline
+        # print params to console
         for k, v in kwargs.items():
-            print("-> {0:.<30}".format(k) + f"{v}")
+            print("-> {0:.<30}".format(k) + f"{v}", flush=True)
 
         line_output()

--- a/tests/e2e/test_TCGA_05_4396.py
+++ b/tests/e2e/test_TCGA_05_4396.py
@@ -129,7 +129,6 @@ def test_pipeline_ssb192(tmp_path):
         seed=-1,
         transcripts=objects.TranscriptPaths.defaults(),
         genomes=objects.GenomePaths.GRCh37(),
-        n_samples=0,
     )
     _run_and_assert(params)
 
@@ -162,7 +161,6 @@ def test_pipeline_ssb7(tmp_path):
         seed=-1,
         transcripts=objects.TranscriptPaths.defaults(),
         genomes=objects.GenomePaths.GRCh37(),
-        n_samples=0,
     )
 
     _run_and_assert(params)
@@ -197,7 +195,6 @@ def test_pipeline_ssb7_random(tmp_path):
         seed=333,
         transcripts=objects.TranscriptPaths.defaults(),
         genomes=objects.GenomePaths.GRCh37(),
-        n_samples=0,
     )
 
     _run_and_assert(params)

--- a/tests/e2e/test_TCGA_05_4396.py
+++ b/tests/e2e/test_TCGA_05_4396.py
@@ -129,6 +129,7 @@ def test_pipeline_ssb192(tmp_path):
         seed=-1,
         transcripts=objects.TranscriptPaths.defaults(),
         genomes=objects.GenomePaths.GRCh37(),
+        n_samples=0,
     )
     _run_and_assert(params)
 
@@ -161,6 +162,7 @@ def test_pipeline_ssb7(tmp_path):
         seed=-1,
         transcripts=objects.TranscriptPaths.defaults(),
         genomes=objects.GenomePaths.GRCh37(),
+        n_samples=0,
     )
 
     _run_and_assert(params)
@@ -195,6 +197,7 @@ def test_pipeline_ssb7_random(tmp_path):
         seed=333,
         transcripts=objects.TranscriptPaths.defaults(),
         genomes=objects.GenomePaths.GRCh37(),
+        n_samples=0,
     )
 
     _run_and_assert(params)

--- a/tests/units/test_parse_utils.py
+++ b/tests/units/test_parse_utils.py
@@ -1,7 +1,12 @@
+import pathlib
 from argparse import Namespace
 from unittest.mock import patch
 
-from SOPRANO.utils.parse_utils import fix_ns_species_arg, parse_genome_args
+from SOPRANO.utils.parse_utils import (
+    fix_ns_species_arg,
+    parse_args,
+    parse_genome_args,
+)
 
 
 def test__fix_species_arg():
@@ -27,3 +32,42 @@ def test_parse_genome_args(capsys):
         assert args.release == 110
         assert args.primary_assembly is True
         assert args.download_only is False
+
+
+_NAME_FLAG = "-n"
+_BED_FLAG = "-b"
+_INPUT_FLAG = "-i"
+_OUTPUT_FLAG = "-o"
+
+_NAME_VALUE = pathlib.Path("dummy_name")
+_BED_VALUE = pathlib.Path("dummy_bed")
+_INPUT_VALUE = pathlib.Path("dummy_input")
+_OUTPUT_VALUE = pathlib.Path("dummy_output")
+
+
+def test_parse_args(capsys, tmp_path):
+    TEST_ARGS = ["parse_args"]
+
+    for flag, fname in zip(
+        [_NAME_FLAG, _BED_FLAG, _INPUT_FLAG],
+        [_NAME_VALUE, _BED_VALUE, _INPUT_VALUE],
+    ):
+        TEST_ARGS.append(flag)
+        TEST_ARGS.append(tmp_path / fname)
+        TEST_ARGS[-1].touch()
+        TEST_ARGS[-1] = TEST_ARGS[-1].as_posix()
+
+    for flag, dname in zip([_OUTPUT_FLAG], [_OUTPUT_VALUE]):
+        TEST_ARGS.append(flag)
+        TEST_ARGS.append(tmp_path / dname)
+        TEST_ARGS[-1].mkdir()
+        TEST_ARGS[-1] = TEST_ARGS[-1].as_posix()
+
+    with patch("sys.argv", TEST_ARGS):
+        args = parse_args()
+
+        assert pathlib.Path(args.analysis_name).name == _NAME_VALUE.name
+        assert pathlib.Path(args.bed_path).name == _BED_VALUE.name
+
+        # Defaults... TODO: Improve!
+        assert args.n_samples == 0


### PR DESCRIPTION
Major update to CLI capability and behaviour for `soprano-run`:

- Sample model introduced, whereby "samples" are randomizations of some fiducial configuration. Downstream samples are generated using bedtools shuffle seeded from `seed + <sample index>` to preserve reproducibility.
- Pipeline runs for "data" and "samples" are distributed over MPI: e.g., `mpiexec -n 16 run-soprano **params`
- Parameter checks now exist to ensure consistent GlobalParamters are used and analyses are scalable 