### PR TITLE
Fix issue 101

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,13 @@ ensembl_downloads/**/*.fa.gz
 tmp/
 /docs/index.md
 /site/
+
+# Personal dir testing
+pp_evo2/*
+data/*
+zz_beatriz/*
+pp_evo/*
+tmp2/*
+zz_users_angel/*    
+snvs/IBD002_platypus_omit024_filtered_vep.IBD002_012E.vcf
+snvs/PPCG0002a_DNA_vs_PPCG0002b_DNA.filtered.extended.pon.vcf.gz

--- a/src/SOPRANO/core/objects.py
+++ b/src/SOPRANO/core/objects.py
@@ -429,8 +429,9 @@ class GlobalParameters:
         )
 
         joined_df.to_csv(self.samples_path)
-        self.plot_hist()
-
+        if self.n_samples >= 1:
+            self.plot_hist()
+        
     @staticmethod
     def split_joined_df(
         joined_df: pd.DataFrame,

--- a/src/SOPRANO/core/objects.py
+++ b/src/SOPRANO/core/objects.py
@@ -387,7 +387,7 @@ class GlobalParameters:
     @as_single_process()
     def gather(self):
         sample_results_paths = [
-            self.get_sample(idx).results_path for idx in range(self.n_samples)
+            self.get_sample(idx).results_path for idx in range(-1, self.n_samples)
         ]
 
         for expected_results_path in sample_results_paths:


### PR DESCRIPTION
When a sample is 1 it is actually stored as 0 and so the loop through samples needs to be -1:0 this was introduced in feb. Additionally kde had been added since then that only works on 2 or more samples so this needed to be checked on sample size.